### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Ensure that the the license file is part of the source tarball published on PyPI.

Shipping the license file is a requirement for a lot of distributions, e. g., Fedora.